### PR TITLE
docs: update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ### 🎒 前置工作
 
-1. 创建一个公开的 Github Gist（https://gist.github.com/）
+1. 创建一个公开的 Github Gist（https://gist.github.com）
 
 2. 创建一个 GitHub Token，需要勾选 `gist` 权限，复制生成的 Token（https://github.com/settings/tokens/new）
 

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@
 
 1. 创建一个公开的 Github Gist（https://gist.github.com）
 
-2. 创建一个 GitHub Token，需要勾选 `gist` 权限，复制生成的 Token（https://github.com/settings/tokens/new）
+2. 创建一个 GitHub Token，需要勾选 `gist` 权限，复制生成的 Token (https://github.com/settings/tokens/new)
 
-3. 获取网易云音乐用户 ID（https://music.163.com/）
+3. 获取网易云音乐用户 ID（https://music.163.com）
 
     - ID 为个人主页页面（`https://music.163.com/#/user/home?id=xxx`），`id` 后紧跟的那串数字
 


### PR DESCRIPTION
在更改前的 md 中蓝色的网址链接会把末尾的  '）' 也算进去，这样点击蓝色网址就会错误进入 'https://gist.github.com/）'  然后 404